### PR TITLE
CI: add a github action to check dead links

### DIFF
--- a/.github/workflows/markdown-linter.yml
+++ b/.github/workflows/markdown-linter.yml
@@ -1,0 +1,13 @@
+name: Markdown lint
+
+on: [push]
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: 'atalent-labs-404-links'
+      uses: atalent-labs/404-links@3.1.3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hello @yosriady ,
I came across your AMAZING repo and after clicking in a few links I came through a few invalid links...
Then allow me to propose a Github action that would be able to detect the if a link is dead or not 😅.

The Github action used is https://github.com/marketplace/actions/404-links

When I run the Action on my fork here is the result: https://github.com/olivierodo/awesome-api-devtools/actions/runs/4024361441

Preview

![image](https://user-images.githubusercontent.com/4768226/215085255-81b802ef-1ffe-41df-aece-73d795919735.png)





Let me know if you have any question.