### PR TITLE
Add OasForge Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ Contributions are most welcome. Categories are also open to suggestions!
 - [Prism](https://github.com/stoplightio/prism): a set of packages for API mocking and contract testing with OpenAPI v2 (formerly known as Swagger) and OpenAPI v3.x, including mock servers and a validation proxy.
 - [MockingCloud](https://mockingcloud.com): Generate full mock REST APIs with just OpenAPI yaml/json spec files.
 - [Svix Play](https://www.svix.com/play/): Easily inspect, test, and debug incoming webhooks.
+- [OASForge](https://oasforge.dev): An in-browser stateful mock server for OpenAPI descriptions - try out an API with no backend.
+
 
 ### Desktop 
 - [Postman](https://www.getpostman.com/docs/postman/mock_servers/setting_up_mock): Desktop API client and mocking tool.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Contributions are most welcome. Categories are also open to suggestions!
 - [Optic](https://www.useoptic.com/docs/openapi/generate-from-traffic): Verify the accuracy of your OpenAPI 3.x spec using real traffic, and automatically apply patches that keep it up-to-date
 - [RateMyOpenAPI](https://ratemyopenapi.com/): Open-source tools that scans your OpenAPI spec and identifies issues with documentation, security, and SDK generation - and generates a report with fix suggestions.
 - [OpenAPI DevTools](https://github.com/AndrewWalsh/openapi-devtools): Browser extension that generates API specs for any app or website
+- [OASForge](https://oasforge.dev): A browser-based OpenAPI editor with live preview, version-aware validation and quick fixes.  
 
 ## API Specifications
 - [API Commons](http://apicommons.org/): A repository of language-agnostic API specifications / Data Models.


### PR DESCRIPTION
Adds OASForge (https://oasforge.dev/), a free browser-based OpenAPI workbench: editor with live Swagger UI preview, version-aware validation with quick fixes, an in-browser stateful mock server, Postman import and a Swagger 2.0 converter. Source: https://github.com/dikeckaan/swagger-dark-ui (Elastic License 2.0). Everything runs client-side; it is testable directly at the link with no signup.